### PR TITLE
feat: expose hasPermission and hasRoles functions

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useCookie } from '#imports'
+import { ref, useCookie, useNuxtApp } from '#imports'
 const userRoles = useCookie<string[]>('roles')
 const userPermissions = useCookie<string[]>('permissions')
 
@@ -18,6 +18,8 @@ const setPermission = () => {
   userPermissions.value.push(permission.value)
   permission.value = ''
 }
+
+const { $hasPermission, $hasRole } = useNuxtApp()
 </script>
 
 <template>
@@ -54,5 +56,13 @@ const setPermission = () => {
       <input placeholder="permission" type="text" v-model="permission" />
       <button tupe="submit">setPermission</button>
     </form>
+
+    <div style="margin-top: 3rem" v-if="$hasRole('admin')">
+      This section is visible to admins only
+    </div>
+
+    <div style="margin-top: 3rem" v-if="$hasPermission('edit')">
+      This section is visible to user with permission "edit"
+    </div>
   </div>
 </template>

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -116,4 +116,11 @@ export default defineNuxtPlugin((nuxtApp) => {
       return {}
     }
   })
+
+  return {
+    provide: {
+      hasRole,
+      hasPermission
+    }
+  }
 })


### PR DESCRIPTION
With this small change user, have access to the `hasRole` and `hasPermission` functions defined inside the plugin functionality.

Now, we can check for roles or permissions like this:

```ts
const { $hasPermission, $hasRole } = useNuxtApp()

console.log($hasRole('admin'))

console.log($hasPermission('edit_roles'))
```

We can even use those functions directly in any UI of the application.

```vue
<div  v-if="$hasRole('admin')">
  This section is visible to admins only
</div>
```

Closes #2 