### PR TITLE
feat: add config option to have dynamic redirection

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,6 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
-  nuxtPermissions: {}
+  nuxtPermissions: {
+    redirectIfNotAllowed: '/not-allowed' // default: '/'
+  }
 })

--- a/playground/pages/not-allowed.vue
+++ b/playground/pages/not-allowed.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h1>Not allowed</h1>
+    <p>Sorry, you are not allowed to access this page.</p>
+  </div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,13 @@
 import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 
 // Module options TypeScript inteface definition
-export interface ModuleOptions {}
+export interface ModuleOptions {
+  redirectIfNotAllowed: string
+}
+
+const defaults: ModuleOptions = {
+  redirectIfNotAllowed: '/'
+}
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -9,8 +15,9 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'nuxtPermissions'
   },
   // Default configuration options of the Nuxt module
-  defaults: {},
+  defaults,
   setup(options, nuxt) {
+    nuxt.options.runtimeConfig.public.nuxtPermissions = options
     const resolver = createResolver(import.meta.url)
 
     // Do not add the extension since the `.ts` will be transpiled to `.mjs` after `npm run prepack`

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,6 +1,9 @@
-import { defineNuxtPlugin, useCookie, addRouteMiddleware } from '#app'
+import { defineNuxtPlugin, useCookie, addRouteMiddleware, useRuntimeConfig } from '#app'
+import { ModuleOptions } from '../module';
 
 export default defineNuxtPlugin((nuxtApp) => {
+  const config: ModuleOptions = useRuntimeConfig().public.nuxtPermissions
+
   const userRoles = useCookie<string | string[]>('roles')
   const userPermissions = useCookie<string | string[]>('permissions')
 
@@ -53,7 +56,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       return from.fullPath
     }
 
-    return '/'
+    return config.redirectIfNotAllowed
   })
 
   function hasNotPermission(binding: string | string[] | undefined) {


### PR DESCRIPTION
This PR adds a config option to change the route where users are redirected when they cannot see a page.

To use it we have to add the `nuxtPermissions` property on our `nuxt-config` like this:

```ts
export default defineNuxtConfig({
  modules: ['../src/module'],
  nuxtPermissions: {
    redirectIfNotAllowed: '/not-allowed' 
  }
})
```

Closes #1 